### PR TITLE
Close #28 by updating dependencies for 2020

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
+
+# Don't commit the dot dirs
 .idea
 .gradle
-/build/
+.project
+.settings
+
+# Ignore build outputs
+build/
+target/
 
 # Ignore Gradle GUI config
 gradle-app.setting
@@ -10,6 +17,3 @@ gradle-app.setting
 
 # Cache of project
 .gradletasknamecache
-
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,15 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
-        maven { url "http://repo.spring.io/libs-snapshot" }
+        maven { url 'http://repo.spring.io/libs-snapshot' }
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.2.RELEASE")
+        classpath('org.springframework.boot:spring-boot-gradle-plugin:2.2.6.RELEASE')
     }
 }
+
+group 'com.gingeleski'
+version '2020.04.09'
 
 apply plugin: 'java'
 apply plugin: 'idea'
@@ -17,51 +20,38 @@ apply plugin: 'io.spring.dependency-management'
 
 jar {
     baseName = 'sample-spring-boot-api'
-    version =  '0.1.0'
-}
-/*
-bootRepackage {
-    mainClass = 'com.demo.BlazeMeterApi'
+    version =  '2020.04.09'
 }
 
-dependencyManagement {
-    imports {
-        mavenBom 'io.spring.platform:platform-bom:Brussels-SR2'
-    }
-}
-*/
 repositories {
     mavenCentral()
     jcenter()
-    maven { url "http://repo.spring.io/libs-snapshot" }
+    maven { url 'http://repo.spring.io/libs-snapshot' }
 }
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile group: 'org.springframework', name: 'spring-core'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-security'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
-    compile group: 'org.springframework.security.oauth', name: 'spring-security-oauth2'
+    implementation group: 'org.springframework', name: 'spring-core', version: '5.2.5.RELEASE'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: '2.2.6.RELEASE'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: '2.2.6.RELEASE'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '2.2.6.RELEASE'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.2.6.RELEASE'
+    implementation group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version: '2.2.6.RELEASE'
 
-    compile group: 'info.cukes', name: 'cucumber-spring', version: '1.2.5'
-    compile group: 'info.cukes', name: 'cucumber-junit', version: '1.2.5'
+    // * Warning these are hella old dependencies that needs to be refactored away *
+    implementation group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1'
+    implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+    // * End warning *
 
-    compile group: 'org.codehaus.groovy.modules.http-builder', name: 'http-builder', version: '0.7.1'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
 
-    compile group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1'
-    compile group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.0'
+    testImplementation group: 'junit', name: 'junit', version: '4.13'
 
-    //compile group: 'org.springframework', name: 'spring-aop', version: '2.5.6'
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.2.6.RELEASE'
 
-    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
-    testCompile group: 'org.springframework.security', name: 'spring-security-test'
-    testCompile group: 'junit', name: 'junit'
-}
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '4.6'
+    testImplementation group: 'io.cucumber', name: 'cucumber-core', version: '5.6.0'
+    testImplementation group: 'io.cucumber', name: 'cucumber-java', version: '5.6.0'
+    testImplementation group: 'io.cucumber', name: 'cucumber-junit', version: '5.6.0'
 }

--- a/src/test/java/cucumber/security/ParserStepDefs.java
+++ b/src/test/java/cucumber/security/ParserStepDefs.java
@@ -1,8 +1,8 @@
 package cucumber.security;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.When;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
+import io.cucumber.java.en.Then;
 
 public class ParserStepDefs {
 

--- a/src/test/java/cucumber/security/RequestStepDefs.java
+++ b/src/test/java/cucumber/security/RequestStepDefs.java
@@ -1,8 +1,8 @@
 package cucumber.security;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.When;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
+import io.cucumber.java.en.Then;
 import org.springframework.http.*;
 import org.springframework.http.client.*;
 import org.springframework.web.client.RestTemplate;

--- a/src/test/java/cucumber/security/RunSecurityIntegrationCukeTests.java
+++ b/src/test/java/cucumber/security/RunSecurityIntegrationCukeTests.java
@@ -2,11 +2,12 @@ package cucumber.security;
 
 import org.junit.runner.RunWith;
 
-import cucumber.api.junit.*;
-import cucumber.api.CucumberOptions;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(format = {"pretty", "html:build/cucumber", "json:build/cucumber.json"},
-        features={"src/test/resources/features/security"}, tags={"@SecurityTest", "@IntegrationTest", "~@IgnoreTest"})
+@CucumberOptions(plugin = { "pretty", "html:target/cucumber", "json:build/cucumber.json" },
+                 features={ "src/test/resources/features/security" },
+                 tags={ "@SecurityTest", "@IntegrationTest", "~@IgnoreTest" })
 public class RunSecurityIntegrationCukeTests {
 }


### PR DESCRIPTION
This builds (`gradle assemble`) but fails a couple tests that were not functionally working before.

Fixing the tests is outside the scope of this issue (#28).